### PR TITLE
refactor: MarkdownContentHelper로 변경

### DIFF
--- a/src/main/java/kr/minimalest/core/domain/post/service/MarkdownContentHelper.java
+++ b/src/main/java/kr/minimalest/core/domain/post/service/MarkdownContentHelper.java
@@ -5,11 +5,15 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.commonmark.node.*;
 import org.commonmark.parser.Parser;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Service
+@Primary
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class MarkdownContentHelper implements ContentHelper {
 


### PR DESCRIPTION
## 변경 사항
- 에디터 포맷 **위지웍(wysiwyg) -> Markdown** 으로 변경에 따른 리팩토링
  - 기존 `ContentHelper`의 주입을 `HtmlContentHelper`에서 `MarkdownContentHelper`로 변경